### PR TITLE
Set cookies as secure by default

### DIFF
--- a/source/oswframe.cookie/stable/frame/namespaces/osWFrame/Core/Cookie.php
+++ b/source/oswframe.cookie/stable/frame/namespaces/osWFrame/Core/Cookie.php
@@ -74,7 +74,10 @@ class Cookie {
 	 * @param bool|null $httponly
 	 * @return bool
 	 */
-	public static function setCookie(string $name, string $value=null, int $expires=null, string $path=null, string $domain=null, bool $secure=null, bool $httponly=null):bool {
+	public static function setCookie(string $name, string $value=null, int $expires=null, string $path=null, string $domain=null, ?bool $secure=null, bool $httponly=null):bool {
+        if(is_null($secure)){
+            $secure = !empty($_SERVER['HTTPS']);
+        }
 		if (self::isCookiesEnabled()===true) {
 			return setcookie($name, $value, $expires, $path, $domain, $secure, $httponly);
 		}

--- a/source/tools.main/stable/oswtools/frame/namespaces/osWFrame/Core/Cookie.php
+++ b/source/tools.main/stable/oswtools/frame/namespaces/osWFrame/Core/Cookie.php
@@ -74,7 +74,10 @@ class Cookie {
 	 * @param bool|null $httponly
 	 * @return bool
 	 */
-	public static function setCookie(string $name, string $value=null, int $expires=null, string $path=null, string $domain=null, bool $secure=null, bool $httponly=null):bool {
+	public static function setCookie(string $name, string $value=null, int $expires=null, string $path=null, string $domain=null, ?bool $secure=null, bool $httponly=null):bool {
+        if(is_null($secure)){
+            $secure = !empty($_SERVER['HTTPS']);
+        }
 		if (self::isCookiesEnabled()===true) {
 			return setcookie($name, $value, $expires, $path, $domain, $secure, $httponly);
 		}


### PR DESCRIPTION
If a cookies SameSite attribute is set to "None",
Secure must be set as well or it will be interpreted as "Lax".

To still be sent in Iframe contexts, like Instagram's or Facebook's app webview, SameSite "None" is required.

Note: Standards related to the Cookie SameSite attribute recently changed:
>[developer.mozilla.org - SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)